### PR TITLE
Set timeout to undefined instead of Infinity by default

### DIFF
--- a/src/Native/Geolocation.js
+++ b/src/Native/Geolocation.js
@@ -57,7 +57,7 @@ function fromOptions(options)
 {
 	return {
 		enableHighAccuracy: options.enableHighAccuracy,
-		timeout: options.timeout._0 || Infinity,
+		timeout: options.timeout._0,
 		maximumAge: options.maximumAge._0 || 0
 	};
 }


### PR DESCRIPTION
When using default options, timeout was set to Infinity and this worked fine for 
most browsers. Some recent change to Safari made it impossible to use Inifnity. 
Having timeout = Infinity in Safari would immeditely return an error.

More details here: https://github.com/elm-lang/geolocation/issues/5